### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 flask.py"

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@
 	* `python -m pip install -r requirements.txt`
 	* On *nix - `python3` + above command
 * `python testgoogle.py` or `python3 ...` as above
+## Ignore:
+[![Run on Repl.it](https://repl.it/badge/github/SomethingGeneric/APW-Timeline)](https://repl.it/github/SomethingGeneric/APW-Timeline)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@mattmert/APW-Timeline).